### PR TITLE
Add accessibility info

### DIFF
--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -10,6 +10,9 @@ moz-berlin:
     - Enter the stairway C located at the very back
     - Go up to floor 3
     - Walk through the open door
+  accessibility:
+    wheelchair: true
+    toilet: true
 bitcrowd:
   short: bitcrowd office
   name: bitcrowd office
@@ -52,6 +55,10 @@ co-up:
   city: Berlin
   web: http://co-up.de/
   osm: https://www.openstreetmap.org/?mlat=52.500587&mlon=13.419115&zoom=18
+  accessibility:
+    wheelchair: true
+    toilet: false
+    comments: "Please contact the organiser, the lift needs to be operated by them."
 wire:
   short: Wire
   name: Wire

--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -49,8 +49,8 @@ blacklane:
   web: https://www.blacklane.com/
   osm: https://www.openstreetmap.org/?mlat=52.484844&mlon=13.3571&zoom=18
 co-up:
-  short: Co-Up
-  name: Co-Up
+  short: co.up
+  name: co.up
   street: Adalbertstraße 8
   city: Berlin
   web: http://co-up.de/
@@ -58,7 +58,7 @@ co-up:
   accessibility:
     wheelchair: true
     toilet: false
-    comments: "Please contact the organiser, the lift needs to be operated by them."
+    comment: "Please contact the organiser, the lift needs to be operated by them."
 wire:
   short: Wire
   name: Wire

--- a/_includes/location-accessibility.html
+++ b/_includes/location-accessibility.html
@@ -1,0 +1,39 @@
+<div class="location-accessibility">  
+  <h1 class="section-headline">Accessibility info</h1>
+  <div class="text">
+  {% if location.accessibility %}
+    <p>
+      <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
+        <span itemprop="name">Wheelchair Accessible</span>:
+        {% if location.accessibility.wheelchair %}
+        <meta itemprop="value" content="{{ location.accessibility.wheelchair }}">Yes</meta>
+        {% else %}
+        <meta itemprop="value" content="{{ location.accessibility.wheelchair }}">No</meta>
+        {% endif %}
+      </span>
+    </p>
+    <p>
+      <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
+        <span itemprop="name">Accessible Toilet</span>:
+        {% if location.accessibility.toilet %}
+        <meta itemprop="value" content="{{ location.accessibility.toilet }}">Yes</meta>
+        {% else %}
+        <meta itemprop="value" content="{{ location.accessibility.toilet }}">No</meta>
+        {% endif %}
+      </span>
+    </p>
+    {% if location.accessibility.comment %}
+    <p>
+      <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
+        <span itemprop="name">Comment</span>:
+        <meta itemprop="value" content="{{ location.accessibility.comment }}">{{ location.accessibility.comment }}</meta>
+      </span>
+    </p>
+    {% endif %}
+  {% else %}
+    <p>
+        No accessibility info available for this location.
+    </p>
+  {% endif %}
+  </div>
+</div>

--- a/_includes/location.html
+++ b/_includes/location.html
@@ -31,5 +31,38 @@
       </div>
       {% endif %}
     </div>
+    <div class="location-accessibility">
+      <h1 class="section-headline">Accessibility info</h1>
+      {% if location.accessibility %}
+      <p>
+        <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
+          <span itemprop="name">Wheelchair Accessible</span>:
+          {% if location.accessibility.wheelchair %}
+          <meta itemprop="value" content="{{ location.accessibility.wheelchair }}">Yes</meta>
+          {% else %}
+          <meta itemprop="value" content="{{ location.accessibility.wheelchair }}">No</meta>
+          {% endif %}
+        </span>
+      </p>
+      <p>
+        <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
+          <span itemprop="name">Accessible Toilet</span>:
+          {% if location.accessibility.toilet %}
+          <meta itemprop="value" content="{{ location.accessibility.toilet }}">Yes</meta>
+          {% else %}
+          <meta itemprop="value" content="{{ location.accessibility.toilet }}">No</meta>
+          {% endif %}
+        </span>
+      </p>
+      {% if location.accessibility.comment %}
+      <p>
+        <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
+          <span itemprop="name">Comment</span>:
+          <meta itemprop="value" content="{{ location.accessibility.comment }}">{{ location.accessibility.comment }}</meta>
+        </span>
+      </p>
+      {% endif %}
+    </div>
+    {% endif %}
   </div>
 </section>

--- a/_includes/location.html
+++ b/_includes/location.html
@@ -30,39 +30,7 @@
         {{ location.directions | markdownify }}
       </div>
       {% endif %}
+      {% include location-accessibility.html location=location %}
     </div>
-    <div class="location-accessibility">
-      <h1 class="section-headline">Accessibility info</h1>
-      {% if location.accessibility %}
-      <p>
-        <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
-          <span itemprop="name">Wheelchair Accessible</span>:
-          {% if location.accessibility.wheelchair %}
-          <meta itemprop="value" content="{{ location.accessibility.wheelchair }}">Yes</meta>
-          {% else %}
-          <meta itemprop="value" content="{{ location.accessibility.wheelchair }}">No</meta>
-          {% endif %}
-        </span>
-      </p>
-      <p>
-        <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
-          <span itemprop="name">Accessible Toilet</span>:
-          {% if location.accessibility.toilet %}
-          <meta itemprop="value" content="{{ location.accessibility.toilet }}">Yes</meta>
-          {% else %}
-          <meta itemprop="value" content="{{ location.accessibility.toilet }}">No</meta>
-          {% endif %}
-        </span>
-      </p>
-      {% if location.accessibility.comment %}
-      <p>
-        <span itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
-          <span itemprop="name">Comment</span>:
-          <meta itemprop="value" content="{{ location.accessibility.comment }}">{{ location.accessibility.comment }}</meta>
-        </span>
-      </p>
-      {% endif %}
-    </div>
-    {% endif %}
   </div>
 </section>

--- a/about.md
+++ b/about.md
@@ -3,10 +3,14 @@ layout: page
 title: About
 ---
 
-Berline.rs is a group of Rustaceans formed around and from the Rust Hack & Learn Berlin.
+Berline.rs is the website of the Berlin Rust Community. That is currently:
 
-In contrast to the users group, it takes more the form of working group. Instead of working on our own and focusing on learning, we try to discuss and design libraries that the Rust ecosystem is lacking. These will then be implemented subsequently.
+* The Rust Hack & Learn
+* The Rust Show & Tell
+* The Rust Users Group
+* The Berlin RustFest Team
 
-The aim is to improve the success rate of projects by collective ownership and maintenance. The exact mechanics around this are still in flux.
+We are an inclusive group an would love you to attend!
 
-Membership is open to people of all skill levels. You don't need to be in Berlin, but in-person meetings will be held here. 
+The group is uses the [Berlin Code of Conduct](https://berlincodeofconduct.org). On top
+of that, we ensure that our meetups are accessible to the extend possible.


### PR DESCRIPTION
Needs some styling issues cleaned up (visible on both of the newest meetups)
On the bindgen one, one of the infos falls to the left, on the Show and Tell, the Header is too wide.